### PR TITLE
ci: adicionar hack para usar excecoes em quem faz push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+#          persist-credentials: false
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -71,7 +72,7 @@ jobs:
             @semantic-release/npm@9.0.1
             @semantic-release/release-notes-generator@10.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_SQUID_TOKEN }}
 
       - name: version
         id: version


### PR DESCRIPTION
para entender a mudanca necessaria para atravessar o processo de 3 validacoes, o bot de changelog e versionamente precisa ter auth token de admin como personal token, no caso o meu, pra poder fazer push na master, criar versoes, editar changelog etc.
 https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch 